### PR TITLE
Upgrade to luminance 0.41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,15 @@ readme = "README.md"
 repository = "https://github.com/JohnDoneth/luminance-glyph"
 
 [dependencies]
-luminance = "0.39"
-luminance-derive = "0.5"
+luminance = "0.41"
+luminance-derive = "0.6"
 glyph_brush = "0.7"
 log = "0.4.8"
+luminance-front = "0.2"
+glfw = "0.39.1"
 
 [dev-dependencies]
-luminance-derive = "0.5"
-luminance-glfw = "0.12"
-luminance-glutin = "0.9"
+luminance-derive = "0.6"
+luminance-glfw = "0.13"
+luminance-glutin = "0.10"
+luminance-windowing = "^0.9"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut back_buffer = surface.back_buffer().unwrap();
 
     'app: loop {
-        // FIXME: This doesn't seem to work for window events on linux/wayland(mutter)
+        surface.window.glfw.poll_events();
         for (_, event) in surface.events_rx.try_iter() {
             match event {
                 WindowEvent::Close | WindowEvent::Key(Key::Escape, _, Action::Release, _) => {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,15 +1,21 @@
+use glfw::{Action, Context, Key, WindowEvent};
 use glyph_brush::Text;
 use luminance::context::GraphicsContext as _;
 use luminance::pipeline::PipelineState;
-use luminance_glfw::{Action, GlfwSurface, Key, Surface, WindowDim, WindowEvent, WindowOpt};
+use luminance_glfw::GlfwSurface;
 use luminance_glyph::{ab_glyph, GlyphBrushBuilder, Section};
+use luminance_windowing::{WindowDim, WindowOpt};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut surface = GlfwSurface::new(
-        WindowDim::Windowed(1024, 720),
+    let mut surface = GlfwSurface::new_gl33(
         "Luminance Glyph",
-        WindowOpt::default().set_num_samples(2),
+        WindowOpt::default()
+            .set_num_samples(2)
+            .set_dim(WindowDim::Windowed {
+                width: 1024,
+                height: 720,
+            }),
     )
     .expect("GLFW surface creation");
 
@@ -22,7 +28,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut back_buffer = surface.back_buffer().unwrap();
 
     'app: loop {
-        for event in surface.poll_events() {
+        // FIXME: This doesn't seem to work for window events on linux/wayland(mutter)
+        for (_, event) in surface.events_rx.try_iter() {
             match event {
                 WindowEvent::Close | WindowEvent::Key(Key::Escape, _, Action::Release, _) => {
                     break 'app
@@ -44,9 +51,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             resize = false;
         }
 
+        let (width, height) = surface.window.get_size();
         glyph_brush.queue(Section {
             screen_position: (30.0, 30.0),
-            bounds: (surface.width() as f32, surface.height() as f32),
+            bounds: (width as f32, height as f32),
             text: vec![Text::default()
                 .with_text("Hello luminance_glyph!")
                 .with_color([1.0, 1.0, 1.0, 1.0])
@@ -56,17 +64,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         glyph_brush.process_queued(&mut surface);
 
-        surface.pipeline_builder().pipeline(
+        let render = surface.new_pipeline_gate().pipeline(
             &back_buffer,
             &PipelineState::default().set_clear_color([0.2, 0.2, 0.2, 1.0]),
             |mut pipeline, mut shd_gate| {
-                glyph_brush
-                    .draw_queued(&mut pipeline, &mut shd_gate, 1024, 720)
-                    .expect("failed to render glyphs");
+                glyph_brush.draw_queued(&mut pipeline, &mut shd_gate, 1024, 720)
             },
         );
 
-        surface.swap_buffers();
+        render.assume().into_result()?;
+        surface.window.swap_buffers();
     }
 
     Ok(())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -66,7 +66,7 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     /// Builds a `GlyphBrush` in the given `glow::Context`.
     pub fn build<C>(self, context: &mut C) -> GlyphBrush<F, H>
     where
-        C: GraphicsContext,
+        C: GraphicsContext<Backend = luminance_front::Backend>,
     {
         GlyphBrush::<F, H>::new(context, self.inner)
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -9,7 +9,7 @@ use luminance_derive::UniformInterface;
 use luminance_derive::{Semantics, Vertex};
 use luminance_front::blending::{Blending, Equation, Factor};
 use luminance_front::context::GraphicsContext;
-use luminance_front::pipeline::{TextureBinding, Pipeline as LuminancePipeline};
+use luminance_front::pipeline::{Pipeline as LuminancePipeline, TextureBinding};
 use luminance_front::pixel::NormUnsigned;
 use luminance_front::render_state::RenderState;
 use luminance_front::shader::{Program, Uniform};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,23 +4,24 @@ use crate::ab_glyph::{point, Rect};
 use crate::Region;
 use cache::Cache;
 
-use luminance::blending::{Equation, Factor};
-use luminance::context::GraphicsContext;
-use luminance::pipeline::BoundTexture;
-use luminance::pipeline::Pipeline as LuminancePipeline;
-use luminance::pipeline::ShadingGate;
-use luminance::pixel::NormUnsigned;
-use luminance::render_state::RenderState;
-use luminance::shader::program::Program;
-use luminance::shader::program::Uniform;
-use luminance::tess::{Mode, Tess, TessBuilder};
-use luminance::texture::Dim2;
+use luminance::pipeline::PipelineError;
 use luminance_derive::UniformInterface;
 use luminance_derive::{Semantics, Vertex};
+use luminance_front::blending::{Blending, Equation, Factor};
+use luminance_front::context::GraphicsContext;
+use luminance_front::pipeline::{TextureBinding, Pipeline as LuminancePipeline};
+use luminance_front::pixel::NormUnsigned;
+use luminance_front::render_state::RenderState;
+use luminance_front::shader::{Program, Uniform};
+use luminance_front::shading_gate::ShadingGate;
+use luminance_front::tess::{Interleaved, Mode, Tess, TessBuilder};
+use luminance_front::texture::Dim2;
+
+type VertexIndex = u32;
 
 pub struct Pipeline {
     program: Program<Semantics, (), ShaderInterface>,
-    vertex_array: Option<Tess>,
+    vertex_array: Option<Tess<(), VertexIndex, Instance, Interleaved>>,
     cache: Cache,
 }
 
@@ -112,18 +113,19 @@ impl Instance {
 #[derive(UniformInterface)]
 struct ShaderInterface {
     transform: Uniform<[[f32; 4]; 4]>,
-
-    font_sampler: Uniform<&'static BoundTexture<'static, Dim2, NormUnsigned>>,
+    font_sampler: Uniform<TextureBinding<Dim2, NormUnsigned>>,
 }
 
 impl Pipeline {
-    pub fn new<C>(ctx: &mut C, cache_width: u32, cache_height: u32) -> Pipeline
+    pub fn new<C>(ctx: &mut C, cache_width: u32, cache_height: u32) -> Self
     where
-        C: GraphicsContext,
+        C: GraphicsContext<Backend = luminance_front::Backend>,
     {
         let cache = Cache::new(ctx, cache_width, cache_height);
 
-        let program = Program::<Semantics, (), ShaderInterface>::from_strings(None, VS, None, FS)
+        let program = ctx
+            .new_shader_program::<Semantics, (), ShaderInterface>()
+            .from_strings(VS, None, None, FS)
             .expect("shader failed to compile")
             .program;
 
@@ -134,35 +136,33 @@ impl Pipeline {
         }
     }
 
-    pub fn draw<'a, C>(
+    pub fn draw<'a>(
         &mut self,
         pipeline: &mut LuminancePipeline<'a>,
-        shading_gate: &mut ShadingGate<'a, C>,
+        shading_gate: &mut ShadingGate<'a>,
         transform: [f32; 16],
         _region: Option<Region>,
-    ) where
-        C: GraphicsContext,
-    {
+    ) -> Result<(), PipelineError> {
         if let Some(vao) = &self.vertex_array {
-            let bound_texture = pipeline.bind_texture(&self.cache.texture);
+            let bound_texture = pipeline.bind_texture(&mut self.cache.texture)?;
 
             // Start shading with our program.
-            shading_gate.shade(&self.program, |iface, mut rdr_gate| {
-                iface.transform.update(to_4x4(&transform));
-                iface.font_sampler.update(&bound_texture);
+            shading_gate.shade(&mut self.program, |mut iface, uni, mut rdr_gate| {
+                iface.set(&uni.transform, to_4x4(&transform));
+                iface.set(&uni.font_sampler, bound_texture.binding());
 
                 // Start rendering things with the default render state provided by luminance.
                 rdr_gate.render(
-                    &RenderState::default().set_blending((
-                        Equation::Additive,
-                        Factor::SrcAlpha,
-                        Factor::SrcAlphaComplement,
-                    )),
-                    |mut tess_gate| {
-                        tess_gate.render(vao);
-                    },
-                );
-            });
+                    &RenderState::default().set_blending(Blending {
+                        equation: Equation::Additive,
+                        src: Factor::SrcAlpha,
+                        dst: Factor::SrcAlphaComplement,
+                    }),
+                    |mut tess_gate| tess_gate.render(vao),
+                )
+            })
+        } else {
+            Ok(())
         }
     }
 
@@ -172,18 +172,18 @@ impl Pipeline {
 
     pub fn increase_cache_size<C>(&mut self, ctx: &mut C, width: u32, height: u32)
     where
-        C: GraphicsContext,
+        C: GraphicsContext<Backend = luminance_front::Backend>,
     {
         self.cache = Cache::new(ctx, width, height);
     }
 
     pub fn upload<C>(&mut self, ctx: &mut C, instances: &[Instance])
     where
-        C: GraphicsContext,
+        C: GraphicsContext<Backend = luminance_front::Backend>,
     {
         self.vertex_array = Some(
             TessBuilder::new(ctx)
-                .add_instances(instances)
+                .set_instances(instances)
                 .set_vertex_nb(4)
                 .set_mode(Mode::TriangleStrip)
                 .build()

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -1,6 +1,6 @@
 use luminance::context::GraphicsContext;
 use luminance::pixel::NormR8UI;
-use luminance::texture::{Dim2, GenMipmaps, MagFilter, MinFilter, Sampler, Texture, Wrap};
+use luminance_front::texture::{Dim2, GenMipmaps, MagFilter, MinFilter, Sampler, Texture, Wrap};
 pub struct Cache {
     pub(crate) texture: Texture<Dim2, NormR8UI>,
 }
@@ -8,7 +8,7 @@ pub struct Cache {
 impl Cache {
     pub fn new<C>(context: &mut C, width: u32, height: u32) -> Cache
     where
-        C: GraphicsContext,
+        C: GraphicsContext<Backend = luminance_front::Backend>,
     {
         let texture = Texture::new(
             context,
@@ -74,7 +74,7 @@ impl Cache {
         // Cache { texture }
     }
 
-    pub fn update(&self, offset: [u16; 2], size: [u16; 2], data: &[u8]) {
+    pub fn update(&mut self, offset: [u16; 2], size: [u16; 2], data: &[u8]) {
         let offset = [offset[0] as u32, offset[1] as u32];
         let size = [size[0] as u32, size[1] as u32];
 


### PR DESCRIPTION
This fixes #3 by upgrading to the luminance version of 0.41.
It uses the `luminance-front` for abstraction over the luminance `Backend`.
There is one public api change in that the draw functions return an `PipelineError` instead of a `String` (`draw_queued_with_transform_and_scissoring`, `draw_queued`, `draw_queued_with_transform_and_scissoring`).