### PR TITLE
Remove luminance-front dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,10 @@ readme = "README.md"
 repository = "https://github.com/JohnDoneth/luminance-glyph"
 
 [dependencies]
-luminance = "0.41"
+luminance = "0.42"
 luminance-derive = "0.6"
 glyph_brush = "0.7"
 log = "0.4.8"
-luminance-front = "0.2"
 
 [dev-dependencies]
 glfw = "0.39.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,9 @@ luminance-derive = "0.6"
 glyph_brush = "0.7"
 log = "0.4.8"
 luminance-front = "0.2"
-glfw = "0.39.1"
 
 [dev-dependencies]
-luminance-derive = "0.6"
+glfw = "0.39.1"
 luminance-glfw = "0.13"
 luminance-glutin = "0.10"
 luminance-windowing = "^0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,8 +274,8 @@ impl<F: Font, H: BuildHasher> GlyphBrush<F, H> {
 }
 
 /// Helper function to generate a generate a transform matrix.
+#[rustfmt::skip]
 pub fn orthographic_projection(width: u32, height: u32) -> [f32; 16] {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
     [
         2.0 / width as f32, 0.0, 0.0, 0.0,
         0.0, -2.0 / height as f32, 0.0, 0.0,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -25,8 +25,8 @@ pub struct Pipeline {
     cache: Cache,
 }
 
-const VS: &'static str = include_str!("./shaders/vertex.glsl");
-const FS: &'static str = include_str!("./shaders/fragment.glsl");
+const VS: &str = include_str!("./shaders/vertex.glsl");
+const FS: &str = include_str!("./shaders/fragment.glsl");
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Semantics)]
 pub enum Semantics {

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -1,14 +1,24 @@
-use luminance::context::GraphicsContext;
-use luminance::pixel::NormR8UI;
-use luminance_front::texture::{Dim2, GenMipmaps, MagFilter, MinFilter, Sampler, Texture, Wrap};
-pub struct Cache {
-    pub(crate) texture: Texture<Dim2, NormR8UI>,
+use luminance::{
+    backend,
+    context::GraphicsContext,
+    pixel::NormR8UI,
+    texture::{Dim2, GenMipmaps, MagFilter, MinFilter, Sampler, Texture, Wrap},
+};
+
+pub struct Cache<B>
+where
+    B: ?Sized + backend::texture::Texture<Dim2, NormR8UI>,
+{
+    pub(crate) texture: Texture<B, Dim2, NormR8UI>,
 }
 
-impl Cache {
-    pub fn new<C>(context: &mut C, width: u32, height: u32) -> Cache
+impl<B> Cache<B>
+where
+    B: ?Sized + backend::texture::Texture<Dim2, NormR8UI>,
+{
+    pub fn new<C>(context: &mut C, width: u32, height: u32) -> Self
     where
-        C: GraphicsContext<Backend = luminance_front::Backend>,
+        C: GraphicsContext<Backend = B>,
     {
         let texture = Texture::new(
             context,


### PR DESCRIPTION
This removes the `luminance-front` dependency from the library, opting to use the `luminance::backend` traits to specify what the backend requires.
I believe this change makes sense, as `luminance-front` says on it's [`README`](https://github.com/phaazon/luminance-rs/blob/master/luminance-front/README.md):
> If you are writing a luminance middleware, please stick to the luminance crate and its polymorphic types.
This makes code that is backend agnostic be able to use this library.

This is a non-backwards compatible change, as it adds generic bounds on several types and functions, but I have not modified the version number.

This PR also exports `Instance`, as it's required for downstream crates to be able to use the generic bounds.

---
The first 2 commits are unrelated to removing the `luminance-front` dependency, but in order to work on the repo, I had to do these fixes, as I didn't have `glfw` installed on my machine, and the library itself doesn't depend on `glfw`, only the examples.

I also upgraded to luminance `0.42`, as it seemed like a minor change and allowed me to perform tests using another library I own that uses `0.42`.