### PR TITLE
Upgrade to Luminance 0.45, bump glyph_brush dep, and add backend trait synonym

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.14"
 luminance = "0.44.1"
 
 [dev-dependencies]
-glfw = "0.42.0"
+glfw = "0.41.0"
 luminance-gl = "0.17.0"
 luminance-glfw = "0.16.0"
 luminance-glutin = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/JohnDoneth/luminance-glyph"
 version = "0.2.0"
 
 [dependencies]
-glyph_brush = "0.7.2"
+glyph_brush = "0.7.3"
 log = "0.4.14"
-luminance = "0.44.0"
+luminance = "0.44.1"
 
 [dev-dependencies]
-glfw = "0.41.0"
+glfw = "0.42.0"
 luminance-gl = "0.17.0"
 luminance-glfw = "0.16.0"
 luminance-glutin = "0.12.0"
-luminance-windowing = "0.10.0"
+luminance-windowing = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,10 @@ version = "0.2.0"
 [dependencies]
 glyph_brush = "0.7.3"
 log = "0.4.14"
-luminance = "0.44.1"
+luminance = "0.45.0"
 
 [dev-dependencies]
-glfw = "0.41.0"
-luminance-gl = "0.17.0"
-luminance-glfw = "0.16.0"
-luminance-glutin = "0.12.0"
-luminance-windowing = "0.10.1"
+glfw = "0.42.0"
+luminance-gl = "0.18.0"
+luminance-glfw = "0.17.0"
+luminance-glutin = "0.13.0"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,21 +1,22 @@
-use glfw::{Action, Context as _, Key, WindowEvent};
+use glfw::{Action, Context as _, Key, SwapInterval, WindowEvent, WindowMode};
 use glyph_brush::Text;
 use luminance::{context::GraphicsContext as _, pipeline::PipelineState};
-use luminance_glfw::GlfwSurface;
+use luminance_glfw::{GlfwSurface, GlfwSurfaceError};
 use luminance_glyph::{ab_glyph, GlyphBrushBuilder, Section};
-use luminance_windowing::{WindowDim, WindowOpt};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let surface = GlfwSurface::new_gl33(
-        "Luminance Glyph",
-        WindowOpt::default()
-            .set_num_samples(2)
-            .set_dim(WindowDim::Windowed {
-                width: 1024,
-                height: 720,
-            }),
-    )
+    let surface = GlfwSurface::new(|glfw| {
+        let (mut window, events) = glfw
+            .create_window(1024, 720, "Luminance Glyph", WindowMode::Windowed)
+            .ok_or(GlfwSurfaceError::UserError(()))?;
+
+        window.make_current();
+        window.set_all_polling(true);
+        glfw.set_swap_interval(SwapInterval::Sync(1));
+
+        Ok((window, events))
+    })
     .expect("GLFW surface creation");
 
     let mut context = surface.context;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,8 @@
 use super::GlyphBrush;
-use crate::{GlyphBrushBackend, Instance};
+use crate::GlyphBrushBackend;
 use core::hash::BuildHasher;
 use glyph_brush::{ab_glyph::Font, delegate_glyph_brush_builder_fns, DefaultSectionHasher};
-use luminance::{
-    backend, context::GraphicsContext, pipeline::TextureBinding, pixel::NormR8UI,
-    pixel::NormUnsigned, tess::Interleaved, texture::Dim2,
-};
+use luminance::context::GraphicsContext;
 
 /// Builder for a [`GlyphBrush`](struct.GlyphBrush.html).
 pub struct GlyphBrushBuilder<F, H = DefaultSectionHasher> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,5 @@
 use super::GlyphBrush;
-use crate::Instance;
+use crate::{GlyphBrushBackend, Instance};
 use core::hash::BuildHasher;
 use glyph_brush::{ab_glyph::Font, delegate_glyph_brush_builder_fns, DefaultSectionHasher};
 use luminance::{
@@ -67,15 +67,7 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     pub fn build<C>(self, context: &mut C) -> GlyphBrush<C::Backend, F, H>
     where
         C: GraphicsContext,
-        C::Backend: backend::texture::Texture<Dim2, NormR8UI>
-            + backend::shader::Shader
-            + backend::tess::Tess<(), u32, Instance, Interleaved>
-            + backend::pipeline::PipelineBase
-            + backend::pipeline::PipelineTexture<Dim2, NormR8UI>
-            + backend::render_gate::RenderGate
-            + backend::tess_gate::TessGate<(), u32, Instance, Interleaved>,
-        [[f32; 4]; 4]: backend::shader::Uniformable<C::Backend>,
-        TextureBinding<Dim2, NormUnsigned>: backend::shader::Uniformable<C::Backend>,
+        C::Backend: GlyphBrushBackend,
     {
         GlyphBrush::new(context, self.inner)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ use pipeline::Pipeline;
 pub use builder::GlyphBrushBuilder;
 pub use glyph_brush::ab_glyph;
 pub use glyph_brush::{
-    BuiltInLineBreaker, Extra, FontId, GlyphCruncher, GlyphPositioner, HorizontalAlign, Layout,
-    LineBreak, LineBreaker, Section, SectionGeometry, SectionGlyph, SectionGlyphIter, SectionText,
-    Text, VerticalAlign,
+    BuiltInLineBreaker, Extra, FontId, GlyphCruncher, GlyphPositioner, GlyphVertex,
+    HorizontalAlign, Layout, LineBreak, LineBreaker, Section, SectionGeometry, SectionGlyph,
+    SectionGlyphIter, SectionText, Text, VerticalAlign,
 };
-pub use pipeline::Instance;
+pub use pipeline::{Instance, LeftTop, RightBottom, TexLeftTop, TexRightBottom, VertexColor};
 
 use ab_glyph::{Font, FontArc, Rect};
 
@@ -252,6 +252,16 @@ where
     where
         C: GraphicsContext<Backend = B>,
     {
+        self.process_queued_with_vertex_constructor(context, Instance::from_vertex)
+    }
+
+    pub fn process_queued_with_vertex_constructor<C>(
+        &mut self,
+        context: &mut C,
+        into_vertex: impl Fn(GlyphVertex) -> Instance,
+    ) where
+        C: GraphicsContext<Backend = B>,
+    {
         let pipeline = &mut self.pipeline;
 
         let mut brush_action;
@@ -264,7 +274,7 @@ where
 
                     pipeline.update_cache(offset, size, tex_data);
                 },
-                Instance::from_vertex,
+                &into_vertex,
             );
 
             match brush_action {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -8,11 +8,10 @@ use crate::{
 use cache::Cache;
 
 use luminance::{
-    backend,
     blending::{Blending, Equation, Factor},
     context::GraphicsContext,
     pipeline::{Pipeline as LuminancePipeline, PipelineError, TextureBinding},
-    pixel::{NormR8UI, NormUnsigned},
+    pixel::NormUnsigned,
     render_state::RenderState,
     shader::{types::Mat44, Program, Uniform},
     shading_gate::ShadingGate,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -56,11 +56,11 @@ pub enum Semantics {
 #[derive(Clone, Copy, Debug, PartialEq, Vertex)]
 #[vertex(sem = "Semantics", instanced = "true")]
 pub struct Instance {
-    left_top: LeftTop,
-    right_bottom: RightBottom,
-    tex_left_top: TexLeftTop,
-    tex_right_bottom: TexRightBottom,
-    color: VertexColor,
+    pub left_top: LeftTop,
+    pub right_bottom: RightBottom,
+    pub tex_left_top: TexLeftTop,
+    pub tex_right_bottom: TexRightBottom,
+    pub color: VertexColor,
 }
 
 impl Instance {

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -2,7 +2,7 @@ use luminance::{
     backend,
     context::GraphicsContext,
     pixel::NormR8UI,
-    texture::{Dim2, GenMipmaps, MagFilter, MinFilter, Sampler, Texture, Wrap},
+    texture::{Dim2, MagFilter, MinFilter, Sampler, TexelUpload, Texture, Wrap},
 };
 
 pub struct Cache<B>
@@ -20,10 +20,10 @@ where
     where
         C: GraphicsContext<Backend = B>,
     {
+        let texels = &vec![0; (width * height) as usize][..];
         let texture = context
-            .new_texture_no_texels(
+            .new_texture(
                 [width, height],
-                0,
                 Sampler {
                     wrap_r: Wrap::ClampToEdge,
                     wrap_s: Wrap::ClampToEdge,
@@ -31,6 +31,10 @@ where
                     min_filter: MinFilter::Linear,
                     mag_filter: MagFilter::Linear,
                     depth_comparison: None,
+                },
+                TexelUpload::BaseLevel {
+                    texels,
+                    mipmaps: None,
                 },
             )
             .expect("failed to create texture");
@@ -89,7 +93,14 @@ where
         let size = [size[0] as u32, size[1] as u32];
 
         self.texture
-            .upload_part_raw(GenMipmaps::No, offset, size, data)
+            .upload_part_raw(
+                offset,
+                size,
+                TexelUpload::BaseLevel {
+                    texels: data,
+                    mipmaps: None,
+                },
+            )
             .expect("failed to upload to texture region");
 
         // let [offset_x, offset_y] = offset;


### PR DESCRIPTION
Hi! This is just some stuff I've had in a fork for a couple weeks, which was based on using the Luminance master branch. Now that 0.45 is out as of yesterday, figured I'd submit a PR. Aside from upgrading the Luminance version and swapping around how the `Uniformable` trait works, I added a `GlyphBrushBackend` trait synonym to get rid of the overly verbose bounds on the backend type parameter everywhere - though it's not as specific for the individual bounds, so I understand if that's not acceptable. Hope you like it though, cheers! :)